### PR TITLE
Add an empty configuration

### DIFF
--- a/empty/.golangci.yaml
+++ b/empty/.golangci.yaml
@@ -1,0 +1,4 @@
+---
+# empty file to force using the default settings
+# otherwise golangci-lint looks for .golangci.yaml files in folders above current one
+# this may cause issues

--- a/empty/README.md
+++ b/empty/README.md
@@ -1,0 +1,7 @@
+# Empty settings
+
+One way to use the default settings is to use `--no-config` parameter.
+
+Another is to create an empty YAML file
+
+See [.golangci.yaml](.golangci.yaml)


### PR DESCRIPTION
Add an empty configuration

An empty file to force using the default settings

This can be used when golangci-lint looks for .golangci.yaml files in folders above current one

Fixes
- #1
