### PR TITLE
feat: add the default rules

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -9,3 +9,8 @@ rules:
     # the node "on:" present in each GitHub Actions workflow file
     ignore: |
       .github/
+
+  line-length:
+    max: 200
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false

--- a/01-defaults/.golangci.yaml
+++ b/01-defaults/.golangci.yaml
@@ -1,18 +1,21 @@
 ---
 linters:
-  # These linters are enabled by default
-  # They can be disable by moving them to the 'disable' key
+  # some linters are enabled by default
+  # https://golangci-lint.run/usage/linters/
+  #
+  # enable some extra linters
   enable:
     # Errcheck is a program for checking for unchecked errors in Go code.
     - errcheck
+
     # Linter for Go source code that specializes in simplifying code.
     - gosimple
+
     # Vet examines Go source code and reports suspicious constructs.
     - govet
+
     # Detects when assignments to existing variables are not used.
     - ineffassign
+
     # It's a set of rules from staticcheck. See https://staticcheck.io/
     - staticcheck
-  disable:
-  # empty by default
-  # but you can any linter here, even the default ones

--- a/01-defaults/README.md
+++ b/01-defaults/README.md
@@ -4,9 +4,26 @@ These are the currently available linter that are enabled in the current last `g
 
 See [.golangci.yaml](.golangci.yaml)
 
+## Enabled linters
+
+### errcheck
+ Errcheck is a program for checking for unchecked errors in Go code.
+
+### gosimple
+ Linter for Go source code that specializes in simplifying code.
+
+### govet
+ Vet examines Go source code and reports suspicious constructs.
+
+### ineffassign
+ Detects when assignments to existing variables are not used.
+
+### staticcheck
+ It's a set of rules from staticcheck. See https://staticcheck.io/
+
 ## Changelog
 
-- 2024-06-26 - golangci-lint:1.59.1
+- 2024-06-28 - golangci-lint:1.59.1
 
   initial version
 


### PR DESCRIPTION
It's important to start from a valid base.

revive linters are often a trap for people because of the way the default
linters are working

Fixes #3
