### PR TITLE
small fix for revive: context-as-argument

### DIFF
--- a/01-defaults/README.md
+++ b/01-defaults/README.md
@@ -1,6 +1,6 @@
 # Default settings
 
-These are the currently available linter that are enabled in the current last `golangci-lint` version available today (1.59.1)
+These are the currently available linter that are enabled in the current last `golangci-lint` version available today (1.60.3)
 
 See [.golangci.yml](.golangci.yml)
 

--- a/02-basic/.golangci.yml
+++ b/02-basic/.golangci.yml
@@ -30,3 +30,77 @@ linters:
     # Fast, configurable, extensible, flexible, and beautiful linter for Go.
     # Drop-in replacement of golint.
     - revive
+
+linters-settings:
+  revive:
+    rules:
+      # these are the default revive rules
+      # you can remove the whole "rules" node if you want
+      # BUT
+      # ! /!\ they all need to be present when you want to add more rules than the default ones
+      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+
+      # Blank import should be only in a main or test package, or have a comment justifying it.
+      - name: blank-imports
+
+      # context.Context() should be the first parameter of a function when provided as argument.
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+
+      # Basic types should not be used as a key in `context.WithValue`
+      - name: context-keys-type
+
+      # Importing with `.` makes the programs much harder to understand
+      - name: dot-imports
+
+      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+      - name: empty-block
+
+      # for better readability, variables of type `error` must be named with the prefix `err`.
+      - name: error-naming
+
+      # for better readability, the errors should be last in the list of returned values by a function.
+      - name: error-return
+
+      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+      - name: error-strings
+
+      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+      - name: errorf
+
+      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+      - name: increment-decrement
+
+      # highlights redundant else-blocks that can be eliminated from the code
+      - name: indent-error-flow
+
+      # This rule suggests a shorter way of writing ranges that do not use the second value.
+      - name: range
+
+      # receiver names in a method should reflect the struct name (p for Person, for example)
+      - name: receiver-naming
+
+      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+      - name: redefines-builtin-id
+
+      # redundant else-blocks that can be eliminated from the code.
+      - name: superfluous-else
+
+      # prevent confusing name for variables when using `time` package
+      - name: time-naming
+
+      # warns when an exported function or method returns a value of an un-exported type.
+      - name: unexported-return
+
+      # spots and proposes to remove unreachable code. also helps to spot errors
+      - name: unreachable-code
+
+      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+      - name: unused-parameter
+
+      # report when a variable declaration can be simplified
+      - name: var-declaration
+
+      # warns when initialism, variable or package naming conventions are not followed.
+      - name: var-naming

--- a/03-safe/.golangci.yml
+++ b/03-safe/.golangci.yml
@@ -72,6 +72,8 @@ linters-settings:
 
       # context.Context() should be the first parameter of a function when provided as argument.
       - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
 
       # Basic types should not be used as a key in `context.WithValue`
       - name: context-keys-type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-09-01
+### Fixed
+- context-as-argument default setting should allow \*testing.T
+
+### Changed
+- added default revive linters explicitly in 02-basic
+
 ## [1.0.0] - 2024-06-29
 ### Added
 - initial version


### PR DESCRIPTION
Configurations were tested against golangci-lint 1.60.3

Added the default revive linters to 02-basic
