### PR TITLE
feat: create 10-cautious

### DIFF
--- a/10-cautious/.golangci.yml
+++ b/10-cautious/.golangci.yml
@@ -1,0 +1,264 @@
+---
+# golangci-lint configuration file made by @ccoVeille
+# Source: https://github.com/ccoVeille/golangci-lint-config-examples/
+# Author: @ccoVeille
+# License: MIT
+# Variant: 10-cautious
+# Version: v1.2.0
+#
+linters:
+  # some linters are enabled by default
+  # https://golangci-lint.run/usage/linters/
+  #
+  # enable some extra linters
+  enable:
+    # Errcheck is a program for checking for unchecked errors in Go code.
+    - errcheck
+
+    # Linter for Go source code that specializes in simplifying code.
+    - gosimple
+
+    # Vet examines Go source code and reports suspicious constructs.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. See https://staticcheck.io/
+    - staticcheck
+
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go.
+    # Drop-in replacement of golint.
+    - revive
+
+    # check imports order and makes it always deterministic.
+    - gci
+
+    # make sure to use t.Helper() when needed
+    - thelper
+
+    # mirror suggests rewrites to avoid unnecessary []byte/string conversion
+    - mirror
+
+    # detect the possibility to use variables/constants from the Go standard library.
+    - usestdlibvars
+
+    # Finds commonly misspelled English words.
+    - misspell
+
+    # Checks for duplicate words in the source code.
+    - dupword
+
+    # linter to detect errors invalid key values count
+    - loggercheck
+
+    # detects nested contexts in loops or function literals
+    - fatcontext
+
+    # checks if package imports are in a list of acceptable packages.
+    - depguard
+
+linters-settings:
+  gci:  # define the section orders for imports
+    sections:
+      # Standard section: captures all standard packages.
+      - standard
+      # Default section: catchall that is not standard or custom
+      - default
+      # linters that related to local tool, so they should be separated
+      - localmodule
+
+  revive:
+    rules:
+      # Check for commonly mistaken usages of the sync/atomic package
+      - name: atomic
+
+      # Blank import should be only in a main or test package, or have a comment justifying it.
+      - name: blank-imports
+
+      # Spots comments not starting with a space
+      - name: comment-spacings
+
+      # context.Context() should be the first parameter of a function when provided as argument.
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+
+      # Basic types should not be used as a key in `context.WithValue`
+      - name: context-keys-type
+
+      # warns on some common mistakes when using defer statement.
+      - name: defer
+
+      # Importing with `.` makes the programs much harder to understand
+      - name: dot-imports
+
+      # suggest to simplify if-then-else constructions when possible
+      - name: early-return
+
+      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+      - name: empty-block
+
+      # for better readability, variables of type `error` must be named with the prefix `err`.
+      - name: error-naming
+
+      # for better readability, the errors should be last in the list of returned values by a function.
+      - name: error-return
+
+      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+      - name: error-strings
+
+      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+      - name: errorf
+
+      # Checking if an error is nil to just after return the error or nil is redundant.
+      - name: if-return
+
+      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+      - name: increment-decrement
+
+      # highlights redundant else-blocks that can be eliminated from the code
+      - name: indent-error-flow
+
+      # This rule suggests a shorter way of writing ranges that do not use the second value.
+      - name: range
+
+      # receiver names in a method should reflect the struct name (p for Person, for example)
+      - name: receiver-naming
+
+      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+      - name: redefines-builtin-id
+
+      # redundant else-blocks that can be eliminated from the code.
+      - name: superfluous-else
+
+      # prevent confusing name for variables when using `time` package
+      - name: time-naming
+
+      # warns when an exported function or method returns a value of an un-exported type.
+      - name: unexported-return
+
+      # spots and proposes to remove unreachable code. also helps to spot errors
+      - name: unreachable-code
+
+      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+      - name: unused-parameter
+
+      # warns on useless break statements in case clauses of switch and select statements
+      - name: useless-break
+
+      # report when a variable declaration can be simplified
+      - name: var-declaration
+
+      # warns when initialism, variable or package naming conventions are not followed.
+      - name: var-naming
+
+  depguard:
+    rules:
+      obsolete:
+        deny:
+          - pkg: "golang.org/x/net/context"
+            desc: "Should be replaced by standard lib context package (Go 1.7+)"
+
+          - pkg: "github.com/pkg/errors"
+            desc: "Should be replaced by standard lib errors package (Go 1.13+)"
+
+          - pkg: "golang.org/x/xerrors"
+            desc: "Should be replaced by standard lib errors package (Go 1.13+)"
+
+          - pkg: github.com/go-errors/errors
+            desc: "Should be replaced by standard lib errors package"
+
+          - pkg: "io/ioutil"
+            desc: "Should be replaced by standard lib os package (Go 1.16+)"
+
+          - pkg: "golang.org/x/exp/slices"
+            desc: "Should be replaced by slices (Go 1.21+)"
+
+          - pkg: "golang.org/x/exp/maps"
+            desc: "Should be replaced by standard lib maps package (Go 1.21+)"
+
+          - pkg: "math/rand$"
+            desc: "Should be replaced by standard lib math/rand/v2 package (Go 1.23+)"
+
+          - pkg: "golang.org/x/syscall"
+            desc: "Should be replaced by golang.org/x/sys or os package according to Go maintainers. More information: https://golang.org/s/go1.4-syscall"
+
+          - pkg: "golang.org/x/crypto/ed25519"
+            desc: "Should be replaced by standard lib crypto/ed25519 package"
+
+          - pkg: "github.com/golang/protobuf"
+            desc: "Should be replaced by google.golang.org/protobuf package (github.com/golang/protobuf is deprecated)"
+
+          - pkg: "github.com/gogo/protobuf"
+            desc: "Should be replaced by google.golang.org/protobuf package (github.com/gogo/protobuf is deprecated)"
+
+          - pkg: "github.com/golang/protobuf/proto"
+            desc: "Should be replaced by google.golang.org/protobuf/proto package (github.com/golang/protobuf/proto is deprecated)"
+
+          - pkg: "github.com/gogo/status"
+            desc: "Should be replaced by google.golang.org/grpc/status package (github.com/gogo/status is deprecated)"
+
+      logs:
+        deny:
+          - pkg: "github.com/prometheus/common/log"
+            desc: "Could be replaced by standard lib log/slog package"
+
+          - pkg: "github.com/sirupsen/logrus"
+            desc: "Should be replaced by standard lib log/slog package"
+
+          - pkg: github.com/siddontang/go-log/log
+            desc: "Could be replaced by standard lib log/slog package"
+
+          - pkg: github.com/siddontang/go/log
+            desc: "Could be replaced by standard lib log/slog package"
+
+          - pkg: github.com/mailgun/log
+            desc: "Could be replaced by standard lib log/slog package"
+
+          - pkg: github.com/saferwall/pe/log
+            desc: "Could be replaced by standard lib log/slog package"
+
+      recommended:
+        deny:
+          - pkg: "go.uber.org/atomic"
+            desc: "Could be replaced by standard lib sync/atomic package"
+
+          - pkg: "github.com/hashicorp/go-multierror"
+            desc: "Could be replaced by errors.Join (Go 1.20+)"
+
+  forbidigo:
+    forbid:
+      # this one could be moved to ldez/exptostd
+      - p: "constraints\\.Ordered"
+        msg: "Use standard lib cmp.Ordered instead (Go 1.21+)"
+
+      # doesn't work ?
+      - pkg: "^golang.org/x/exp/constraints$"
+        p: "^.*$"
+        msg: "WIP"
+
+      - p: ^atomic\.(Add|CompareAndSwap|Load|Store|Swap).
+        msg: Go 1.19 atomic types should be used instead.
+  dupword:
+    # Keywords used to ignore detection.
+    # Default: []
+    ignore: []
+    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # Default ("") is to use a neutral variety of English.
+    locale: US
+
+    # List of words to ignore
+    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+    ignore-words: []
+    #  - valor
+    #  - and
+
+    # Extra word corrections.
+    extra-words: []
+    #  - typo: "whattever"
+    #    correction: "whatever"

--- a/10-cautious/README.md
+++ b/10-cautious/README.md
@@ -1,0 +1,147 @@
+# Cautious Settings
+
+See [.golangci.yml](.golangci.yml)
+
+It's [03-safe](../03-safe) plus :
+- [depguard](#depguard)
+- [revive](#revive)
+  - [atomic](#atomic)
+  - [comment-spacings](#comment-spacings)
+  - [defer](#defer)
+  - [early-return](early-return)
+  - [if-return](if-return)
+  - [useless-break](useless-break)
+
+## License
+
+License: MIT
+
+Source: [@ccoVeille](https://github.com/ccoVeille/golangci-lint-config-examples)
+## Enabled linters
+
+### errcheck
+ Errcheck is a program for checking for unchecked errors in Go code.
+
+### gosimple
+ Linter for Go source code that specializes in simplifying code.
+
+### govet
+ Vet examines Go source code and reports suspicious constructs.
+
+### ineffassign
+ Detects when assignments to existing variables are not used.
+
+### staticcheck
+ It's a set of rules from staticcheck. See https://staticcheck.io/
+
+### gci
+ check imports order and makes it always deterministic.
+
+### thelper
+ make sure to use `t.Helper()` when needed
+
+### mirror
+ mirror suggests rewrites to avoid unnecessary []byte/string conversion
+
+### usestdlibvars
+ detect the possibility to use variables/constants from the Go standard library.
+
+### misspell
+Finds commonly misspelled English words.
+
+### dupword
+Checks for duplicate words in the source code.
+
+### loggercheck
+Detects errors invalid key values count
+
+### fatcontext
+Detects nested contexts in loops or function literals
+
+### depguard
+Detects package obsolete imports
+
+### revive
+ Fast, configurable, extensible, flexible, and beautiful linter for Go.
+ Drop-in replacement of golint.
+
+#### atomic
+Check for commonly mistaken usages of the sync/atomic package
+
+#### blank-imports
+Blank import should be only in a main or test package, or have a comment justifying it.
+
+#### comment-spacings
+Spots comments not starting with a space
+
+#### context-as-argument
+`context.Context()` should be the first parameter of a function when provided as argument.
+
+#### context-keys-type
+Basic types should not be used as a key in `context.WithValue`
+
+#### defer
+warns on some common mistakes when using defer statement.
+
+#### dot-imports
+Importing with `.` makes the programs much harder to understand
+
+#### early-return
+suggest to simplify if-then-else constructions when possible
+
+#### empty-block
+Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+
+#### error-naming
+for better readability, variables of type `error` must be named with the prefix `err`.
+
+#### error-return
+for better readability, the errors should be last in the list of returned values by a function.
+
+#### error-strings
+for better readability, error messages should not be capitalized or end with punctuation or a newline.
+
+#### errorf
+report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+
+#### if-return
+Checking if an error is nil to just after return the error or nil is redundant.
+
+#### increment-decrement
+incrementing an integer variable by 1 is recommended to be done using the `++` operator
+
+#### indent-error-flow
+highlights redundant else-blocks that can be eliminated from the code
+
+#### range
+This rule suggests a shorter way of writing ranges that do not use the second value.
+
+#### receiver-naming
+receiver names in a method should reflect the struct name (p for Person, for example)
+
+#### redefines-builtin-id
+redefining built-in names (true, false, append, make) can lead to bugs very difficult to detect.
+
+#### superfluous-else
+redundant else-blocks that can be eliminated from the code.
+
+#### time-naming
+prevent confusing name for variables when using `time` package
+
+#### unexported-return
+warns when an exported function or method returns a value of an un-exported type.
+
+#### unreachable-code
+spots and proposes to remove unreachable code. also helps to spot errors
+
+#### unused-parameter
+Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+
+#### useless-break
+warns on useless break statements in case clauses of switch and select statements
+
+#### var-declaration
+report when a variable declaration can be simplified
+
+#### var-naming
+warns when initialism, variable or package naming conventions are not followed.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ These are `.golangci.yml` examples to use in your projects
 - [01-defaults](./01-defaults)
 - [02-basic](./02-basic)
 - [03-safe](./03-safe)
+- [10-cautious](./10-cautious)
 ...
 - [80-reckless](./80-reckless)
 - [90-daredevil](./90-daredevil)


### PR DESCRIPTION
This ruleset is a cautious approach to the dependencies and the code quality.

Compared to 03-safe:
- add depguard to maintain the dependencies (Fixes #32)
- add revive rules
  - atomic
  - comment-spacings
  - defer
  - early-return
  - if-return
  - useless-break
