### PR TITLE
feat: migrate to golangci-lint v2 config format

### DIFF
--- a/00-empty/.golangci.yml
+++ b/00-empty/.golangci.yml
@@ -4,9 +4,11 @@
 # Author: @ccoVeille
 # License: MIT
 # Variant: 01-defaults
-# Version: v1.1.0
+# Version: v2.0.0
 #
-# empty file to force using the default settings
+# this file to force using the default settings
 # otherwise golangci-lint looks for .golangci.yaml files
 # in parent folders
 # this may cause issues
+
+version: "2"

--- a/01-defaults/.golangci.yml
+++ b/01-defaults/.golangci.yml
@@ -4,19 +4,17 @@
 # Author: @ccoVeille
 # License: MIT
 # Variant: 01-defaults
-# Version: v1.1.0
+# Version: v2.0.0
 #
+version: "2"
+
 linters:
   # some linters are enabled by default
   # https://golangci-lint.run/usage/linters/
   #
-  # enable some extra linters
   enable:
     # Errcheck is a program for checking for unchecked errors in Go code.
     - errcheck
-
-    # Linter for Go source code that specializes in simplifying code.
-    - gosimple
 
     # Vet examines Go source code and reports suspicious constructs.
     - govet
@@ -26,3 +24,6 @@ linters:
 
     # It's a set of rules from staticcheck. See https://staticcheck.io/
     - staticcheck
+
+    # Checks Go code for unused constants, variables, functions and types.
+    - unused

--- a/01-defaults/README.md
+++ b/01-defaults/README.md
@@ -12,11 +12,10 @@ Source: [@ccoVeille](https://github.com/ccoVeille/golangci-lint-config-examples)
 
 ## Enabled linters
 
+These are the default ones:
+
 ### errcheck
  Errcheck is a program for checking for unchecked errors in Go code.
-
-### gosimple
- Linter for Go source code that specializes in simplifying code.
 
 ### govet
  Vet examines Go source code and reports suspicious constructs.
@@ -27,4 +26,5 @@ Source: [@ccoVeille](https://github.com/ccoVeille/golangci-lint-config-examples)
 ### staticcheck
  It's a set of rules from staticcheck. See https://staticcheck.io/
 
-
+### unused
+ Checks Go code for unused constants, variables, functions, and types.

--- a/02-basic/.golangci.yml
+++ b/02-basic/.golangci.yml
@@ -4,9 +4,39 @@
 # Author: @ccoVeille
 # License: MIT
 # Variant: 02-basic
-# Version: v1.1.0
+# Version: v2.0.0
 #
+version: "2"
+
+formatters:
+  enable:
+    # format the code with Go standard library
+    - gofmt
+
 linters:
+  exclusions:
+    # these presets where present in the v1 version of golangci-lint
+    # it's interesting to keep them when migrating, but removing them should be the goal
+    presets:
+      # exclude check on comments format in godoc
+      # These are common false positives in poor code
+      # you should not use this on recent code you write from scratch
+      # More information: https://golangci-lint.run/usage/false-positives/#comments
+      - comments
+
+      # Common false positives
+      # feel free to remove this if you don't have any false positives
+      # More information: https://golangci-lint.run/usage/false-positives/#common-false-positives
+      - common-false-positives
+
+      # Legacy preset is not recommended anymore
+      # More information: https://golangci-lint.run/usage/false-positives/#legacy
+      # - legacy
+
+      # std-error-handling is a set of rules that avoid reporting unhandled errors on common functions/methods
+      # More information: https://golangci-lint.run/usage/false-positives/#std-error-handling
+      - std-error-handling
+
   # some linters are enabled by default
   # https://golangci-lint.run/usage/linters/
   #
@@ -14,9 +44,6 @@ linters:
   enable:
     # Errcheck is a program for checking for unchecked errors in Go code.
     - errcheck
-
-    # Linter for Go source code that specializes in simplifying code.
-    - gosimple
 
     # Vet examines Go source code and reports suspicious constructs.
     - govet
@@ -27,80 +54,107 @@ linters:
     # It's a set of rules from staticcheck. See https://staticcheck.io/
     - staticcheck
 
+    # Checks Go code for unused constants, variables, functions and types.
+    - unused
+
     # Fast, configurable, extensible, flexible, and beautiful linter for Go.
     # Drop-in replacement of golint.
     - revive
 
-linters-settings:
-  revive:
-    rules:
-      # these are the default revive rules
-      # you can remove the whole "rules" node if you want
-      # BUT
-      # ! /!\ they all need to be present when you want to add more rules than the default ones
-      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+  settings:
+    revive:
+      rules:
+        # these are the default revive rules
+        # you can remove the whole "rules" node if you want
+        # BUT
+        # ! /!\ they all need to be present when you want to add more rules than the default ones
+        # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
 
-      # Blank import should be only in a main or test package, or have a comment justifying it.
-      - name: blank-imports
+        # Blank import should be only in a main or test package, or have a comment justifying it.
+        - name: blank-imports
 
-      # context.Context() should be the first parameter of a function when provided as argument.
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
+        # context.Context() should be the first parameter of a function when provided as argument.
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T"
 
-      # Basic types should not be used as a key in `context.WithValue`
-      - name: context-keys-type
+        # Basic types should not be used as a key in `context.WithValue`
+        - name: context-keys-type
 
-      # Importing with `.` makes the programs much harder to understand
-      - name: dot-imports
+        # Importing with `.` makes the programs much harder to understand
+        - name: dot-imports
 
-      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
-      - name: empty-block
+        # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+        - name: empty-block
 
-      # for better readability, variables of type `error` must be named with the prefix `err`.
-      - name: error-naming
+        # for better readability, variables of type `error` must be named with the prefix `err`.
+        - name: error-naming
 
-      # for better readability, the errors should be last in the list of returned values by a function.
-      - name: error-return
+        # for better readability, the errors should be last in the list of returned values by a function.
+        - name: error-return
 
-      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
-      - name: error-strings
+        # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+        - name: error-strings
 
-      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
-      - name: errorf
+        # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+        - name: errorf
 
-      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
-      - name: increment-decrement
+        # check naming and commenting conventions on exported symbols.
+        - name: exported
+          arguments:
+            # make error messages clearer
+            - "sayRepetitiveInsteadOfStutters"
 
-      # highlights redundant else-blocks that can be eliminated from the code
-      - name: indent-error-flow
+        # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+        - name: increment-decrement
 
-      # This rule suggests a shorter way of writing ranges that do not use the second value.
-      - name: range
+        # highlights redundant else-blocks that can be eliminated from the code
+        - name: indent-error-flow
 
-      # receiver names in a method should reflect the struct name (p for Person, for example)
-      - name: receiver-naming
+        # This rule suggests a shorter way of writing ranges that do not use the second value.
+        - name: range
 
-      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
-      - name: redefines-builtin-id
+        # receiver names in a method should reflect the struct name (p for Person, for example)
+        - name: receiver-naming
 
-      # redundant else-blocks that can be eliminated from the code.
-      - name: superfluous-else
+        # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+        - name: redefines-builtin-id
 
-      # prevent confusing name for variables when using `time` package
-      - name: time-naming
+        # redundant else-blocks that can be eliminated from the code.
+        - name: superfluous-else
 
-      # warns when an exported function or method returns a value of an un-exported type.
-      - name: unexported-return
+        # prevent confusing name for variables when using `time` package
+        - name: time-naming
 
-      # spots and proposes to remove unreachable code. also helps to spot errors
-      - name: unreachable-code
+        # warns when an exported function or method returns a value of an un-exported type.
+        - name: unexported-return
 
-      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
-      - name: unused-parameter
+        # spots and proposes to remove unreachable code. also helps to spot errors
+        - name: unreachable-code
 
-      # report when a variable declaration can be simplified
-      - name: var-declaration
+        # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+        - name: unused-parameter
 
-      # warns when initialism, variable or package naming conventions are not followed.
-      - name: var-naming
+        # report when a variable declaration can be simplified
+        - name: var-declaration
+
+        # warns when initialism, variable or package naming conventions are not followed.
+        - name: var-naming
+
+output:
+  # Order to use when sorting results.
+  # Possible values: `file`, `linter`, and `severity`.
+  #
+  # If the severity values are inside the following list, they are ordered in this order:
+  #   1. error
+  #   2. warning
+  #   3. high
+  #   4. medium
+  #   5. low
+  # Either they are sorted alphabetically.
+  #
+  # Default: ["file"]
+  sort-order:
+    - linter
+    - severity
+    - file # filepath, line, and column.

--- a/02-basic/README.md
+++ b/02-basic/README.md
@@ -3,6 +3,7 @@
 See [.golangci.yml](.golangci.yml)
 
 It's [01-defaults](../01-defaults) plus :
+- [gofmt](#gofmt)
 - [revive](#revive)
 
 ## License
@@ -11,6 +12,10 @@ License: MIT
 
 golangci-lint configuration file made by @ccoVeille
 Source: https://github.com/ccoVeille/golangci-lint-config-examples/tree/main/02-basics
+
+## Enabled formatters
+### gofmt
+ format the code with Go standard library
 
 ## Enabled linters
 
@@ -32,6 +37,8 @@ Source: https://github.com/ccoVeille/golangci-lint-config-examples/tree/main/02-
 ### revive
  Fast, configurable, extensible, flexible, and beautiful linter for Go.
  Drop-in replacement of golint.
+
+These are the default ones available in revive
 
 #### blank-imports
 Blank import should be only in a main or test package, or have a comment justifying it.
@@ -59,6 +66,9 @@ for better readability, error messages should not be capitalized or end with pun
 
 #### errorf
 report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+
+#### exported
+check naming and commenting conventions on exported symbols.
 
 #### increment-decrement
 incrementing an integer variable by 1 is recommended to be done using the `++` operator

--- a/03-safe/.golangci.yml
+++ b/03-safe/.golangci.yml
@@ -4,9 +4,65 @@
 # Author: @ccoVeille
 # License: MIT
 # Variant: 03-safe
-# Version: v1.1.0
+# Version: v2.0.0
 #
+version: "2"
+
+formatters:
+  enable:
+    # format the code
+    - gofmt
+    # format the block of imports
+    - gci
+
+  settings:
+    # format the code with Go standard library
+    gofmt:
+      # simplify the code
+      # https://pkg.go.dev/cmd/gofmt#hdr-The_simplify_command
+      simplify: true
+      rewrite-rules:
+        # replace `interface{}` with `any` in the code on format
+        - pattern: 'interface{}'
+          replacement: 'any'
+
+    # make sure imports are always in a deterministic order
+    # https://github.com/daixiang0/gci/
+    gci:  # define the section orders for imports
+      sections:
+        # Standard section: captures all standard packages.
+        - standard
+        # Default section: catchall that is not standard or custom
+        - default
+        # linters that related to local tool, so they should be separated
+        - localmodule
+
 linters:
+  exclusions:
+    # these presets where present in the v1 version of golangci-lint
+    # it's interesting to keep them when migrating, but removing them should be the goal
+    presets:
+      # exclude check on comments format in godoc
+      # These are common false positives in poor code
+      # you should not use this on recent code you write from scratch
+      # More information: https://golangci-lint.run/usage/false-positives/#comments
+      #
+      # Please uncomment the following line if your code is not using the godoc format
+      - comments
+
+      # Common false positives
+      # feel free to remove this if you don't have any false positives
+      # More information: https://golangci-lint.run/usage/false-positives/#common-false-positives
+      - common-false-positives
+
+      # Legacy preset is not recommended anymore
+      # More information: https://golangci-lint.run/usage/false-positives/#legacy
+      - legacy
+
+      # std-error-handling is a set of rules that avoid reporting unhandled errors on common functions/methods
+      # More information: https://golangci-lint.run/usage/false-positives/#std-error-handling
+      - std-error-handling
+
   # some linters are enabled by default
   # https://golangci-lint.run/usage/linters/
   #
@@ -14,9 +70,6 @@ linters:
   enable:
     # Errcheck is a program for checking for unchecked errors in Go code.
     - errcheck
-
-    # Linter for Go source code that specializes in simplifying code.
-    - gosimple
 
     # Vet examines Go source code and reports suspicious constructs.
     - govet
@@ -27,12 +80,12 @@ linters:
     # It's a set of rules from staticcheck. See https://staticcheck.io/
     - staticcheck
 
+    # Checks Go code for unused constants, variables, functions and types.
+    - unused
+
     # Fast, configurable, extensible, flexible, and beautiful linter for Go.
     # Drop-in replacement of golint.
     - revive
-
-    # check imports order and makes it always deterministic.
-    - gci
 
     # make sure to use t.Helper() when needed
     - thelper
@@ -52,111 +105,126 @@ linters:
     # linter to detect errors invalid key values count
     - loggercheck
 
+    # detect when a package or method could be replaced by one from the standard library
+    - exptostd
+
     # detects nested contexts in loops or function literals
     - fatcontext
 
-linters-settings:
-  gci:  # define the section orders for imports
-    sections:
-      # Standard section: captures all standard packages.
-      - standard
-      # Default section: catchall that is not standard or custom
-      - default
-      # linters that related to local tool, so they should be separated
-      - localmodule
+    # Reports uses of functions with replacement inside the testing package.
+    - usetesting
 
-  revive:
-    rules:
-      # these are the default revive rules
-      # you can remove the whole "rules" node if you want
-      # BUT
-      # ! /!\ they all need to be present when you want to add more rules than the default ones
-      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+  settings:
+    revive:
+      rules:
+        # these are the default revive rules
+        # you can remove the whole "rules" node if you want
+        # BUT
+        # ! /!\ they all need to be present when you want to add more rules than the default ones
+        # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
 
-      # Blank import should be only in a main or test package, or have a comment justifying it.
-      - name: blank-imports
+        # Blank import should be only in a main or test package, or have a comment justifying it.
+        - name: blank-imports
 
-      # context.Context() should be the first parameter of a function when provided as argument.
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
+        # context.Context() should be the first parameter of a function when provided as argument.
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T"
 
-      # Basic types should not be used as a key in `context.WithValue`
-      - name: context-keys-type
+        # Basic types should not be used as a key in `context.WithValue`
+        - name: context-keys-type
 
-      # Importing with `.` makes the programs much harder to understand
-      - name: dot-imports
+        # Importing with `.` makes the programs much harder to understand
+        - name: dot-imports
 
-      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
-      - name: empty-block
+        # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+        - name: empty-block
 
-      # for better readability, variables of type `error` must be named with the prefix `err`.
-      - name: error-naming
+        # for better readability, variables of type `error` must be named with the prefix `err`.
+        - name: error-naming
 
-      # for better readability, the errors should be last in the list of returned values by a function.
-      - name: error-return
+        # for better readability, the errors should be last in the list of returned values by a function.
+        - name: error-return
 
-      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
-      - name: error-strings
+        # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+        - name: error-strings
 
-      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
-      - name: errorf
+        # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+        - name: errorf
 
-      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
-      - name: increment-decrement
+        # check naming and commenting conventions on exported symbols.
+        - name: exported
+          arguments:
+            # make error messages clearer
+            - "sayRepetitiveInsteadOfStutters"
 
-      # highlights redundant else-blocks that can be eliminated from the code
-      - name: indent-error-flow
+        # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+        - name: increment-decrement
 
-      # This rule suggests a shorter way of writing ranges that do not use the second value.
-      - name: range
+        # highlights redundant else-blocks that can be eliminated from the code
+        - name: indent-error-flow
 
-      # receiver names in a method should reflect the struct name (p for Person, for example)
-      - name: receiver-naming
+        # This rule suggests a shorter way of writing ranges that do not use the second value.
+        - name: range
 
-      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
-      - name: redefines-builtin-id
+        # receiver names in a method should reflect the struct name (p for Person, for example)
+        - name: receiver-naming
 
-      # redundant else-blocks that can be eliminated from the code.
-      - name: superfluous-else
+        # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+        - name: redefines-builtin-id
 
-      # prevent confusing name for variables when using `time` package
-      - name: time-naming
+        # redundant else-blocks that can be eliminated from the code.
+        - name: superfluous-else
 
-      # warns when an exported function or method returns a value of an un-exported type.
-      - name: unexported-return
+        # prevent confusing name for variables when using `time` package
+        - name: time-naming
 
-      # spots and proposes to remove unreachable code. also helps to spot errors
-      - name: unreachable-code
+        # warns when an exported function or method returns a value of an un-exported type.
+        - name: unexported-return
 
-      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
-      - name: unused-parameter
+        # spots and proposes to remove unreachable code. also helps to spot errors
+        - name: unreachable-code
 
-      # report when a variable declaration can be simplified
-      - name: var-declaration
+        # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+        - name: unused-parameter
 
-      # warns when initialism, variable or package naming conventions are not followed.
-      - name: var-naming
+        # report when a variable declaration can be simplified
+        - name: var-declaration
 
-  dupword:
-    # Keywords used to ignore detection.
-    # Default: []
-    ignore: []
-    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
+        # warns when initialism, variable or package naming conventions are not followed.
+        - name: var-naming
 
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # Default ("") is to use a neutral variety of English.
-    locale: US
+    misspell:
+      # Correct spellings using locale preferences for US or UK.
+      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+      # Default ("") is to use a neutral variety of English.
+      locale: US
 
-    # List of words to ignore
-    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
-    ignore-words: []
-    #  - valor
-    #  - and
+      # List of words to ignore
+      # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+      ignore-rules: []
+      #  - valor
+      #  - and
 
-    # Extra word corrections.
-    extra-words: []
-    #  - typo: "whattever"
-    #    correction: "whatever"
+      # Extra word corrections.
+      extra-words: []
+      #  - typo: "whattever"
+      #    correction: "whatever"
+
+output:
+  # Order to use when sorting results.
+  # Possible values: `file`, `linter`, and `severity`.
+  #
+  # If the severity values are inside the following list, they are ordered in this order:
+  #   1. error
+  #   2. warning
+  #   3. high
+  #   4. medium
+  #   5. low
+  # Either they are sorted alphabetically.
+  #
+  # Default: ["file"]
+  sort-order:
+    - linter
+    - severity
+    - file # filepath, line, and column.

--- a/03-safe/README.md
+++ b/03-safe/README.md
@@ -18,6 +18,13 @@ License: MIT
 
 Source: [@ccoVeille](https://github.com/ccoVeille/golangci-lint-config-examples)
 
+## Enabled formatters
+### gofmt
+ format the code with Go standard library
+
+### gci
+ make sure imports are always in a deterministic order
+
 ## Enabled linters
 
 ### errcheck
@@ -34,9 +41,6 @@ Source: [@ccoVeille](https://github.com/ccoVeille/golangci-lint-config-examples)
 
 ### staticcheck
  It's a set of rules from staticcheck. See https://staticcheck.io/
-
-### gci
- check imports order and makes it always deterministic.
 
 ### thelper
  make sure to use `t.Helper()` when needed

--- a/80-reckless/.golangci.yml
+++ b/80-reckless/.golangci.yml
@@ -4,22 +4,45 @@
 # Author: @ccoVeille
 # License: MIT
 # Variant: 80-reckless
-# Version: v1.1.0
+# Version: v2.0.0
 #
+version: "2"
+
+formatters:
+  enable:
+    # format the code
+    - gofmt
+    # format the block of imports
+    - gci
+
+  settings:
+    # format the code with Go standard library
+    gofmt:
+      # simplify the code
+      # https://pkg.go.dev/cmd/gofmt#hdr-The_simplify_command
+      simplify: true
+      rewrite-rules:
+        # replace `interface{}` with `any` in the code on format
+        - pattern: 'interface{}'
+          replacement: 'any'
+
+    # make sure imports are always in a deterministic order
+    # https://github.com/daixiang0/gci/
+    gci:  # define the section orders for imports
+      sections:
+        # Standard section: captures all standard packages.
+        - standard
+        # Default section: catchall that is not standard or custom
+        - default
+        # linters that related to local tool, so they should be separated
+        - localmodule
+
 run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
   timeout: 5m
 
 issues:
-  exclude-use-default: false
-
-  # The list of ids of default excludes to include or disable.
-  # https://golangci-lint.run/usage/false-positives/#default-exclusions
-  # Default: []
-  include:
-    - EXC0014
-
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50
@@ -28,219 +51,185 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
 
 linters:
   # some linters are enabled by default
   # https://golangci-lint.run/usage/linters/
   #
   # enable some extra linters
-  enable-all: true
+  default: all
 
-linters-settings:
-  gci:  # define the section orders for imports
-    sections:
-      # Standard section: captures all standard packages.
-      - standard
-      # Default section: catchall that is not standard or custom
-      - default
-      # linters that related to local tool, so they should be separated
-      - localmodule
+  settings:
+    usestdlibvars:
+      # Suggest the use of http.MethodXX.
+      # Default: true
+      http-method: true
+      # Suggest the use of http.StatusXX.
+      # Default: true
+      http-status-code: true
+      # Suggest the use of time.Weekday.String().
+      # Default: true
+      time-weekday: true
+      # Suggest the use of constants available in time package
+      # Default: false
+      time-layout: true
 
-  usestdlibvars:
-    # Suggest the use of http.MethodXX.
-    # Default: true
-    http-method: true
-    # Suggest the use of http.StatusXX.
-    # Default: true
-    http-status-code: true
-    # Suggest the use of time.Weekday.String().
-    # Default: true
-    time-weekday: true
-    # Suggest the use of constants available in time package
-    # Default: false
-    time-layout: true
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+      checks: ["all"]
 
-  staticcheck:
-    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
-    checks: ["all"]
+    nolintlint:
+      # Enable to require an explanation of nonzero length
+      # after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific
+      # linter being suppressed.
+      # Default: false
+      require-specific: true
 
-  nolintlint:
-    # Enable to require an explanation of nonzero length
-    # after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific
-    # linter being suppressed.
-    # Default: false
-    require-specific: true
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
 
-  govet:
-    enable-all: true
+    gocritic:
+      enable-all: true
+      disabled-checks:
+        # Detects comments with non-idiomatic formatting.
+        # https://go-critic.com/overview.html#commentformatting
+        # Reason: Duplicate with other linters
+        - commentFormatting
 
-  gocritic:
-    enable-all: true
-    disabled-checks:
-      # Detects comments with non-idiomatic formatting.
-      # https://go-critic.com/overview.html#commentformatting
-      # Reason: Duplicate with other linters
-      - commentFormatting
+        # Runs user-defined rules using ruleguard linter.
+        # https://go-critic.com/overview.html#ruleguard
+        # Reason: we don't need it
+        - ruleguard
 
-      # Runs user-defined rules using ruleguard linter.
-      # https://go-critic.com/overview.html#ruleguard
-      # Reason: we don't need it
-      - ruleguard
+        # Detects when default case in switch isn't on 1st or last position.
+        # https://go-critic.com/overview.html#defaultcaseorder
+        # Reason: we don't care
+        - defaultCaseOrder
 
-      # Detects when default case in switch isn't on 1st or last position.
-      # https://go-critic.com/overview.html#defaultcaseorder
-      # Reason: we don't care
-      - defaultCaseOrder
+        # Detects empty string checks that can be written more idiomatically.
+        # https://go-critic.com/overview.html#emptystringtest
+        # Reason: we don't want to enforce it, using len(s) == 0 is ok
+        - emptyStringTest
 
-      # Detects empty string checks that can be written more idiomatically.
-      # https://go-critic.com/overview.html#emptystringtest
-      # Reason: we don't want to enforce it, using len(s) == 0 is ok
-      - emptyStringTest
+        # Detects unwanted dependencies on the evaluation order.
+        # https://go-critic.com/overview.html#evalorder
+        # Reason: require code rewrite for almost nothing
+        - evalOrder
 
-      # Detects unwanted dependencies on the evaluation order.
-      # https://go-critic.com/overview.html#evalorder
-      # Reason: require code rewrite for almost nothing
-      - evalOrder
+        # Detects when imported package names shadowed in the assignments.
+        # https://go-critic.com/overview.html#importshadow
+        # Reason: require code rewrite for almost nothing
+        - importShadow
 
-      # Detects when imported package names shadowed in the assignments.
-      # https://go-critic.com/overview.html#importshadow
-      # Reason: require code rewrite for almost nothing
-      - importShadow
+        # Detects if function parameters could be combined by type and suggest the way to do it.
+        # https://go-critic.com/overview.html#paramtypecombine
+        # Reason: too opinionated
+        - paramTypeCombine
 
-      # Detects if function parameters could be combined by type and suggest the way to do it.
-      # https://go-critic.com/overview.html#paramtypecombine
-      # Reason: too opinionated
-      - paramTypeCombine
+        # Detects expressions like []rune(s)[0] that may cause unwanted rune slice allocation.
+        # https://go-critic.com/overview.html#preferdecoderune
+        # Reason: too opinionated
+        - preferDecodeRune
 
-      # Detects expressions like []rune(s)[0] that may cause unwanted rune slice allocation.
-      # https://go-critic.com/overview.html#preferdecoderune
-      # Reason: too opinionated
-      - preferDecodeRune
+        # Detects WriteRune calls with rune literal argument that is single byte and reports to use WriteByte instead.
+        # https://go-critic.com/overview.html#preferwritebyte
+        # Reason: too opinionated
+        - preferWriteByte
 
-      # Detects WriteRune calls with rune literal argument that is single byte and reports to use WriteByte instead.
-      # https://go-critic.com/overview.html#preferwritebyte
-      # Reason: too opinionated
-      - preferWriteByte
+        # Detects loops that copy big objects during each iteration.
+        # https://go-critic.com/overview.html#rangevalcopy
+        # Reason: we don't care that much about RAM
+        - rangeValCopy
 
-      # Detects loops that copy big objects during each iteration.
-      # https://go-critic.com/overview.html#rangevalcopy
-      # Reason: we don't care that much about RAM
-      - rangeValCopy
+        # Detects TODO comments without detail/assignee.
+        # https://go-critic.com/overview.html#todocommentwithoutdetail
+        # Reason: no need
+        - todoCommentWithoutDetail
 
-      # Detects TODO comments without detail/assignee.
-      # https://go-critic.com/overview.html#todocommentwithoutdetail
-      # Reason: no need
-      - todoCommentWithoutDetail
+        # Ensures that `//nolint` comments include an explanation.
+        # https://go-critic.com/overview.html#whynolint
+        # Reason: nolintlint already enforces it
+        - whyNoLint
 
-      # Ensures that `//nolint` comments include an explanation.
-      # https://go-critic.com/overview.html#whynolint
-      # Reason: nolintlint already enforces it
-      - whyNoLint
+    revive:
+      enable-all-rules: true
+      rules:
+        # we must provide configuration for linter that requires them
+        # enable-all-rules is OK, but many revive linters expect configuration
+        # and cannot work without them
 
-  revive:
-    enable-all-rules: true
-    rules:
-      # we must provide configuration for linter that requires them
-      # enable-all-rules is OK, but many revive linters expect configuration
-      # and cannot work without them
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T"
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
-      - name: add-constant
-        arguments:
-          - maxLitCount: "3"
-            allowStrs: '""'
-            allowInts: "0,1,2"
-            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+        - name: exported
+          arguments:
+            # enables checking public methods of private types
+            - "checkPrivateReceivers"
+            # make error messages clearer
+            - "sayRepetitiveInsteadOfStutters"
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
-      - name: cognitive-complexity
-        severity: warning
-        arguments: [7]
+        # this linter completes errcheck linter, it will report method called without handling the error
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+        - name: unhandled-error
+          arguments: # here are the exceptions we don't want to be reported
+            - "fmt.Print.*"
+            - "fmt.Fprint.*"
+            - "bytes.Buffer.Write"
+            - "bytes.Buffer.WriteByte"
+            - "bytes.Buffer.WriteString"
+            - "strings.Builder.WriteString"
+            - "strings.Builder.WriteRune"
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
+        # disable everything we don't want
+        - name: line-length-limit
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: empty-lines
+          disabled: true
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
-      - name: cyclomatic
-        arguments: [3]
+    dupword:
+      # Keywords used to ignore detection.
+      # Default: []
+      ignore: []
+      #  - "blah" # this will accept "blah blah …" as a valid duplicate word
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        arguments:
-          # enables checking public methods of private types
-          - "checkPrivateReceivers"
-          # make error messages clearer
-          - "sayRepetitiveInsteadOfStutters"
+    misspell:
+      # Correct spellings using locale preferences for US or UK.
+      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+      # Default ("") is to use a neutral variety of English.
+      locale: US
 
-      # this linter completes errcheck linter, it will report method called without handling the error
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
-      - name: unhandled-error
-        arguments: # here are the exceptions we don't want to be reported
-          - "fmt.Print.*"
-          - "fmt.Fprint.*"
-          - "bytes.Buffer.Write"
-          - "bytes.Buffer.WriteByte"
-          - "bytes.Buffer.WriteString"
-          - "strings.Builder.WriteString"
-          - "strings.Builder.WriteRune"
+      # List of words to ignore
+      # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+      ignore-rules: []
+      #  - valor
+      #  - and
 
-      # disable everything we don't want
-      - name: line-length-limit
-        disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: banned-characters
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      - name: function-result-limit
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: file-header
-        disabled: true
-      - name: empty-lines
-        disabled: true
-
-  dupword:
-    # Keywords used to ignore detection.
-    # Default: []
-    ignore: []
-    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
-
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # Default ("") is to use a neutral variety of English.
-    locale: US
-
-    # List of words to ignore
-    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
-    ignore-words: []
-    #  - valor
-    #  - and
-
-    # Extra word corrections.
-    extra-words: []
-    #  - typo: "whattever"
-    #    correction: "whatever"
+      # Extra word corrections.
+      extra-words: []
+      #  - typo: "whattever"
+      #    correction: "whatever"
 
 output:
-  # Make issues output unique by line.
-  # Default: true
-  uniq-by-line: false
-
-  # Sort results by the order defined in `sort-order`.
-  # Default: false
-  sort-results: true
-
   # Order to use when sorting results.
-  # Require `sort-results` to `true`.
   # Possible values: `file`, `linter`, and `severity`.
   #
   # If the severity values are inside the following list, they are ordered in this order:
@@ -256,7 +245,3 @@ output:
     - linter
     - severity
     - file # filepath, line, and column.
-
-  # Show statistics per linter.
-  # Default: false
-  show-stats: true

--- a/90-daredevil/.golangci.yml
+++ b/90-daredevil/.golangci.yml
@@ -4,8 +4,38 @@
 # Author: @ccoVeille
 # License: MIT
 # Variant: 90-daredevil
-# Version: v1.1.0
+# Version: v2.0.0
 #
+version: "2"
+
+formatters:
+  enable:
+    # format the code
+    - gofmt
+    # format the block of imports
+    - gci
+
+  settings:
+    # format the code with Go standard library
+    gofmt:
+      # simplify the code
+      # https://pkg.go.dev/cmd/gofmt#hdr-The_simplify_command
+      simplify: true
+      rewrite-rules:
+        # replace `interface{}` with `any` in the code on format
+        - pattern: 'interface{}'
+          replacement: 'any'
+
+    # make sure imports are always in a deterministic order
+    # https://github.com/daixiang0/gci/
+    gci:  # define the section orders for imports
+      sections:
+        # Standard section: captures all standard packages.
+        - standard
+        # Default section: catchall that is not standard or custom
+        - default
+        # linters that related to local tool, so they should be separated
+        - localmodule
 
 run:
   # Timeout for analysis, e.g. 30s, 5m.
@@ -13,28 +43,6 @@ run:
   timeout: 5m
 
 issues:
-  exclude-use-default: false
-
-  # The list of ids of default excludes to include or disable.
-  # https://golangci-lint.run/usage/false-positives/#default-exclusions
-  # Default: []
-  include:
-    - EXC0001
-    - EXC0002
-    - EXC0003
-    - EXC0004
-    - EXC0005
-    - EXC0006
-    - EXC0007
-    - EXC0008
-    - EXC0009
-    - EXC0010
-    - EXC0011
-    - EXC0012
-    - EXC0013
-    - EXC0014
-    - EXC0015
-
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50
@@ -43,159 +51,99 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
 
 linters:
   # some linters are enabled by default
   # https://golangci-lint.run/usage/linters/
   #
   # enable some extra linters
-  enable-all: true
+  default: all
 
-linters-settings:
-  gci:  # define the section orders for imports
-    sections:
-      # Standard section: captures all standard packages.
-      - standard
-      # Default section: catchall that is not standard or custom
-      - default
-      # linters that related to local tool, so they should be separated
-      - localmodule
+  settings:
+    usestdlibvars:
+      # Suggest the use of http.MethodXX.
+      # Default: true
+      http-method: true
+      # Suggest the use of http.StatusXX.
+      # Default: true
+      http-status-code: true
+      # Suggest the use of time.Weekday.String().
+      # Default: true
+      time-weekday: true
+      # Suggest the use of constants available in time package
+      # Default: false
+      time-layout: true
 
-  usestdlibvars:
-    # Suggest the use of http.MethodXX.
-    # Default: true
-    http-method: true
-    # Suggest the use of http.StatusXX.
-    # Default: true
-    http-status-code: true
-    # Suggest the use of time.Weekday.String().
-    # Default: true
-    time-weekday: true
-    # Suggest the use of constants available in time package
-    # Default: false
-    time-layout: true
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
+      checks: ["all"]
 
-  staticcheck:
-    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
-    checks: ["all"]
+    nolintlint:
+      # Enable to require an explanation of nonzero length
+      # after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific
+      # linter being suppressed.
+      # Default: false
+      require-specific: true
 
-  nolintlint:
-    # Enable to require an explanation of nonzero length
-    # after each nolint directive.
-    # Default: false
-    require-explanation: true
-    # Enable to require nolint directives to mention the specific
-    # linter being suppressed.
-    # Default: false
-    require-specific: true
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
 
-  govet:
-    enable-all: true
+    gocritic:
+      enable-all: true
 
-  gocritic:
-    enable-all: true
+    revive:
+      enable-all-rules: true
+      rules:
+        # we must provide configuration for linter that requires them
+        # enable-all-rules is OK, but many revive linters expect configuration
+        # and cannot work without them
 
-  revive:
-    enable-all-rules: true
-    rules:
-      # we must provide configuration for linter that requires them
-      # enable-all-rules is OK, but many revive linters expect configuration
-      # and cannot work without them
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T"
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
-      - name: add-constant
-        arguments:
-          - maxLitCount: "3"
-            allowStrs: '""'
-            allowInts: "0,1,2"
-            allowFloats: "0.0,0.,1.0,1.,2.0,2."
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+        - name: exported
+          arguments:
+            # enables checking public methods of private types
+            - "checkPrivateReceivers"
+            # make error messages clearer
+            - "sayRepetitiveInsteadOfStutters"
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
-      - name: cognitive-complexity
-        severity: warning
-        arguments: [7]
+    dupword:
+      # Keywords used to ignore detection.
+      # Default: []
+      ignore: []
+      #  - "blah" # this will accept "blah blah …" as a valid duplicate word
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
+    misspell:
+      # Correct spellings using locale preferences for US or UK.
+      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+      # Default ("") is to use a neutral variety of English.
+      locale: US
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
-      - name: cyclomatic
-        arguments: [3]
+      # List of words to ignore
+      # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+      ignore-rules: []
+      #  - valor
+      #  - and
 
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        arguments:
-          # enables checking public methods of private types
-          - "checkPrivateReceivers"
-          # make error messages clearer
-          - "sayRepetitiveInsteadOfStutters"
-
-      # this linter completes errcheck linter, it will report method called without handling the error
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
-      - name: unhandled-error
-        arguments: # here are the exceptions we don't want to be reported
-          - "fmt.Print.*"
-          - "fmt.Fprint.*"
-          - "bytes.Buffer.Write"
-          - "bytes.Buffer.WriteByte"
-          - "bytes.Buffer.WriteString"
-          - "strings.Builder.WriteString"
-          - "strings.Builder.WriteRune"
-
-      # disable everything we don't want
-      - name: line-length-limit
-        disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: banned-characters
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      - name: function-result-limit
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: file-header
-        disabled: true
-      - name: empty-lines
-        disabled: true
-
-  dupword:
-    # Keywords used to ignore detection.
-    # Default: []
-    ignore: []
-    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
-
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # Default ("") is to use a neutral variety of English.
-    locale: US
-
-    # List of words to ignore
-    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
-    ignore-words: []
-    #  - valor
-    #  - and
-
-    # Extra word corrections.
-    extra-words: []
-    #  - typo: "whattever"
-    #    correction: "whatever"
+      # Extra word corrections.
+      extra-words: []
+      #  - typo: "whattever"
+      #    correction: "whatever"
 
 output:
-  # Make issues output unique by line.
-  # Default: true
-  uniq-by-line: false
-
-  # Sort results by the order defined in `sort-order`.
-  # Default: false
-  sort-results: true
-
   # Order to use when sorting results.
-  # Require `sort-results` to `true`.
   # Possible values: `file`, `linter`, and `severity`.
   #
   # If the severity values are inside the following list, they are ordered in this order:
@@ -211,7 +159,3 @@ output:
     - linter
     - severity
     - file # filepath, line, and column.
-
-  # Show statistics per linter.
-  # Default: false
-  show-stats: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-03-31
+### Changed
+- convert everything to golangci-lint v2 configuration format
+- sort results
+
+### Fixed
+- add missing `unused` linter
+- add missing `revive.exported` linter
+
+### Added
+- 03-safe: usetesting & exptostd
+
 ## [1.1.0] - 2024-12-06
 ### Added
 - 80-reckless


### PR DESCRIPTION
- fix forgotten linters:
    - unused
    - revive.exported

- Add recent linters to 03-safe and above:
    - exptostd
    - usetesting

Fixes #40 